### PR TITLE
Fix Rubocop command to support path parameter and JUnit output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 description: |
-  Ruby Linter for Circleci Orb: bash 
+  Ruby Linter for Circleci Orb: bash
   Source: https://github.com/amyroi/circleci-ruby-linter
 commands:
   brakeman:
@@ -12,17 +12,16 @@ commands:
         description: brakeman vesion. default is latest
         type: boolean
     steps:
-    - run:
-        command: bundle exec brakeman -o brakeman-output.tabs --no-progress --separate-models
-          --exit-on-warn
-        name: Run brakeman
-        parallel: << parameters.parallel >>
+      - run:
+          command: bundle exec brakeman -o brakeman-output.tabs --no-progress --separate-models --exit-on-warn
+          name: Run brakeman
+          parallel: << parameters.parallel >>
   eslint:
     description: Run eslint
     steps:
-    - run:
-        command: bin/yarn lint:js
-        name: Run eslint
+      - run:
+          command: bin/yarn lint:js
+          name: Run eslint
   haml-lint:
     description: Run haml-lint
     parameters:
@@ -31,9 +30,9 @@ commands:
         description: haml-lint target paths. default is app/views
         type: string
     steps:
-    - run:
-        command: bundle exec haml-lint << parameters.paths >>
-        name: Run haml-lint
+      - run:
+          command: bundle exec haml-lint << parameters.paths >>
+          name: Run haml-lint
   rails_best_practices:
     description: Run rails_best_practices
     parameters:
@@ -42,15 +41,15 @@ commands:
         description: Run rails_best_practices target paths. default is .
         type: string
     steps:
-    - run:
-        command: bundle exec rails_best_practices << parameters.paths >>
-        name: Run rails_best_practices
+      - run:
+          command: bundle exec rails_best_practices << parameters.paths >>
+          name: Run rails_best_practices
   reek:
     description: Run reek
     steps:
-    - run:
-        command: bundle exec reek -s app lib config spec bin db
-        name: Run reek
+      - run:
+          command: bundle exec reek -s app lib config spec bin db
+          name: Run reek
   rubocop:
     description: Run Rubocop
     parameters:
@@ -63,115 +62,114 @@ commands:
         description: rubocop reports dir. default is $CIRCLE_TEST_REPORTS
         type: string
     steps:
-    - run:
-        command: |
-          mkdir -p << parameters.report_dir >>
-          rubocop_reports_dir="<< parameters.report_dir >>"/rubocop
-          mkdir -p $rubocop_reports_dir
-          bundle exec rubocop --require rubocop-rspec --out $rubocop_reports_dir/junit.xml --format progres
-        files: << parameters.files >>
-        name: Run Rubocop
+      - run:
+          command: |
+            mkdir -p << parameters.report_dir >>
+            rubocop_reports_dir="<< parameters.report_dir >>"/rubocop
+            mkdir -p $rubocop_reports_dir
+            bundle exec rubocop --require rubocop-rspec --format progress --format junit --out $rubocop_reports_dir/junit.xml << parameters.files >>
+          name: Run Rubocop
   stylelint:
     description: Run stylelint
     steps:
-    - run:
-        command: bin/yarn lint:style
-        name: Run stylelint
+      - run:
+          command: bin/yarn lint:style
+          name: Run stylelint
 examples:
   brakeman:
     description: Example of brakeman command
     usage:
+      version: 2.1
+      orbs:
+        ruby-linter: amyroi/ruby-linter@1.0.0
       jobs:
         build:
           docker:
-          - image: circleci/ruby:2.6.3
+            - image: circleci/ruby:2.6.3
           steps:
-          - checkout
-          - ruby-linter/brakeman:
-              parallel: true
-      orbs:
-        ruby-linter: amyroi/ruby-linter@1.0.0
-      version: 2.1
+            - checkout
+            - ruby-linter/brakeman:
+                parallel: true
   eslint:
     description: Example of eslint command
     usage:
+      version: 2.1
+      orbs:
+        ruby-linter: amyroi/ruby-linter@1.0.0
       jobs:
         build:
           docker:
-          - image: circleci/ruby:2.6.3
+            - image: circleci/ruby:2.6.3
           steps:
-          - checkout
-          - ruby-linter/eslint
-      orbs:
-        ruby-linter: amyroi/ruby-linter@1.0.0
-      version: 2.1
+            - checkout
+            - ruby-linter/eslint
   haml-lint:
     description: Example of haml-lint command
     usage:
+      version: 2.1
+      orbs:
+        ruby-linter: amyroi/ruby-linter@1.0.0
       jobs:
         build:
           docker:
-          - image: circleci/ruby:2.6.3
+            - image: circleci/ruby:2.6.3
           steps:
-          - checkout
-          - ruby-linter/haml-lint:
-              paths: app/views
-      orbs:
-        ruby-linter: amyroi/ruby-linter@1.0.0
-      version: 2.1
+            - checkout
+            - ruby-linter/haml-lint:
+                paths: app/views
   rails_best_practices:
     description: Example of rails_best_practices command
     usage:
+      version: 2.1
+      orbs:
+        ruby-linter: amyroi/ruby-linter@1.0.0
       jobs:
         build:
           docker:
-          - image: circleci/ruby:2.6.3
+            - image: circleci/ruby:2.6.3
           steps:
-          - checkout
-          - ruby-linter/rails_best_practices:
-              paths: .
-      orbs:
-        ruby-linter: amyroi/ruby-linter@1.0.0
-      version: 2.1
+            - checkout
+            - ruby-linter/rails_best_practices:
+                paths: .
   reek:
     description: Example of reek command
     usage:
+      version: 2.1
+      orbs:
+        ruby-linter: amyroi/ruby-linter@1.0.0
       jobs:
         build:
           docker:
-          - image: circleci/ruby:2.6.3
+            - image: circleci/ruby:2.6.3
           steps:
-          - checkout
-          - ruby-linter/reek
-      orbs:
-        ruby-linter: amyroi/ruby-linter@1.0.0
-      version: 2.1
+            - checkout
+            - ruby-linter/reek
   rubocop:
     description: Example of rubocop command
     usage:
+      version: 2.1
+      orbs:
+        ruby-linter: amyroi/ruby-linter@1.0.0
       jobs:
         build:
           docker:
-          - image: circleci/ruby:2.6.3
+            - image: circleci/ruby:2.6.3
           steps:
-          - checkout
-          - ruby-linter/rubocop:
-              files: app/**/*.rb lib/**/*.rb config/**/*.rb spec/**/*.rb script/**/*.rb
-              report_dir: $CIRCLE_TEST_REPORTS
-      orbs:
-        ruby-linter: amyroi/ruby-linter@1.0.0
-      version: 2.1
+            - checkout
+            - ruby-linter/rubocop:
+                files: app/**/*.rb lib/**/*.rb config/**/*.rb spec/**/*.rb script/**/*.rb
+                report_dir: $CIRCLE_TEST_REPORTS
   stylelint:
     description: Examples uses stylelint commands
     usage:
+      version: 2.1
+      orbs:
+        ruby-linter: amyroi/ruby-linter@1.0.0
       jobs:
         build:
           docker:
-          - image: circleci/ruby:2.6.3
+            - image: circleci/ruby:2.6.3
           steps:
-          - checkout
-          - ruby-linter/stylelint
-      orbs:
-        ruby-linter: amyroi/ruby-linter@1.0.0
-      version: 2.1
+            - checkout
+            - ruby-linter/stylelint
 

--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@
 CircleCI orb for Ruby Linter
 
 https://circleci.com/orbs/registry/orb/amyroi/ruby-linter#orb-source
+
+## Requirements
+
+The Rubocop command emits a JUnit report using `--format junit`. Ensure your
+project includes a formatter that provides this output, such as the
+[`rubocop-junit-formatter`](https://github.com/sj26/rubocop-junit-formatter)
+gem, and require it (for example with `--require rubocop/formatter/junit_formatter`)
+before invoking the command. Without a JUnit formatter available, Rubocop will
+fail with an "unrecognized formatter junit" error.

--- a/commands/rubocop.yml
+++ b/commands/rubocop.yml
@@ -6,8 +6,7 @@ steps:
           mkdir -p << parameters.report_dir >>
           rubocop_reports_dir="<< parameters.report_dir >>"/rubocop
           mkdir -p $rubocop_reports_dir
-          bundle exec rubocop --require rubocop-rspec --out $rubocop_reports_dir/junit.xml --format progress
-      files: << parameters.files >>
+          bundle exec rubocop --require rubocop-rspec --format progress --format junit --out $rubocop_reports_dir/junit.xml << parameters.files >>
 parameters:
   report_dir:
     type: string
@@ -17,4 +16,5 @@ parameters:
     type: string
     default: "app/**/*.rb lib/**/*.rb config/**/*.rb spec/**/*.rb script/**/*.rb"
     description: "rubocop target paths. default is app lib config spec script"
+
     


### PR DESCRIPTION
## Summary
- fix Rubocop command to forward file paths parameter
- emit JUnit report alongside progress output
- regenerate orb config with updated Rubocop command

## Testing
- `circleci config pack .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a81870333c8322aa989966a859f4b7