### PR TITLE
Fix typo in brakeman command description

### DIFF
--- a/commands/brakeman.yml
+++ b/commands/brakeman.yml
@@ -8,4 +8,4 @@ parameters:
   parallel:
     type: boolean
     default: true
-    description: "brakeman vesion. default is latest"
+    description: "brakeman version. default is latest"


### PR DESCRIPTION
## Summary
- fix typo in brakeman command description

## Testing
- `yamllint commands/brakeman.yml` (errors: missing document start "---"; too many spaces after colon; line too long)


------
https://chatgpt.com/codex/tasks/task_e_68a82009576c8322b68834982791309a